### PR TITLE
- Kalender Denglish

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -1,5 +1,6 @@
 
 locale = de_DE
+locale_utf8 = de_DE.UTF-8
 
 format_month = F Y
 format_day = d.m

--- a/lib/pz.php
+++ b/lib/pz.php
@@ -26,7 +26,7 @@ class pz
         // ini_set("display_errors",1);
         // ob_start();
 
-        setlocale(LC_ALL, pz_i18n::msg('locale'));
+        setlocale(LC_ALL, [pz_i18n::msg('locale_utf8'), pz_i18n::msg('locale')]);
         date_default_timezone_set(self::getDateTimeZone()->getName());
 
         $func = rex_request('func');


### PR DESCRIPTION
Wenn das Sprachpaket de_DE auf dem Server nicht installiert wurde funktioniert setlocale explizit für LC_TIME nicht. Es wurde für diesen Fall nun noch eine Alternative ergänzt.

closed #304 