### PR TITLE
Bugfix calendar refresh

### DIFF
--- a/assets/js/prozer.js
+++ b/assets/js/prozer.js
@@ -408,6 +408,9 @@ function pz_tooltipbox_close()
   $("#overlay").remove();
 }
 
+function isEmpty(val){
+    return (val === undefined || val == null || val.length <= 0) ? true : false;
+}
 /* ******************* Emails **************** */
 
 function pz_open_email(id,link) {

--- a/lib/calendar/calendar_event_screen.php
+++ b/lib/calendar/calendar_event_screen.php
@@ -2994,7 +2994,10 @@ class pz_calendar_event_screen{
 
         }else
         {
-            $return = $header.$form;
+            $script = '<script>
+                var refreshTimeout = refreshTimeout || null;
+                if(!isEmpty(refreshTimeout)){ clearTimeout(refreshTimeout); }</script>';
+            $return = $header.$form.$script;
         }
         $script = '<script>pz_toggleSection(1);</script>';
         $return = '<div id="calendar_event_form" class="design1col"><div id="calendar_event_add" class="design1col xform-add">'.$return.'</div>'.$script.'</div>';

--- a/lib/calendar/calendar_event_screen.php
+++ b/lib/calendar/calendar_event_screen.php
@@ -2984,7 +2984,7 @@ class pz_calendar_event_screen{
 
                 $return = $header.'<p class="xform-info">'.pz_i18n::msg("calendar_event_added").'</p>';
                 $return .= '<script>pz_refresh_calendar_lists();</script>';
-                $return .= pz_screen::getJSDelayedUpdateLayer('calendar_event_add', pz::url('screen', $p['controll'], $p['function'], ['mode' => 'add_calendar_event']), 6000, 'xform-info');
+                $return .= pz_screen::getJSDelayedUpdateLayer('calendar_event_add', pz::url('screen', $p['controll'], $p['function'], ['mode' => 'add_calendar_event', 'day' => $from->format('Ymd')]), 4000, 'xform-info');
 
 
             }else

--- a/lib/screen.php
+++ b/lib/screen.php
@@ -160,9 +160,13 @@ class pz_screen
         return '<script language="Javascript">
                 <!--
                     '.$fadeOut.'
-                    setTimeout(function (){
-                        pz_loadPage("'.$layer.'","'.$link.'")
-                    }, '.$time.');
+                    var refreshTimeout;
+                    function timeoutUpdatelayer() {
+                        refreshTimeout = setTimeout(function (){
+                                            pz_loadPage("'.$layer.'","'.$link.'")
+                                        }, '.$time.');
+                    }
+                    timeoutUpdatelayer();
                 -->
                 </script>';
 


### PR DESCRIPTION
- Neue js function isEmty
- setTimeout wir einer variable zugewiesen, dadurch ist es nun möglich den refresh zu unterbinden

closed #314