### PR TITLE
Issues 386 Sub-Menu Wochenansicht

### DIFF
--- a/lib/calendar/calendars_controller.php
+++ b/lib/calendar/calendars_controller.php
@@ -13,4 +13,18 @@ class pz_calendars_controller extends pz_controller
             return false;
         }
     }
+
+    protected function getSelectDay()
+    {
+        $request_day = rex_request('day', 'string', rex_cookie('calendar_day', 'string', '')); // 20112019 Ymd
+        setcookie('calendar_day', $request_day, time() + 60 + 60 * 24, '/screen/calendars/');
+
+        return $request_day;
+    }
+
+    protected function removeSelectDay()
+    {
+        setcookie('calendar_day', '', -1, '/screen/calendars/');
+        unset($_COOKIE['calendar_day']);
+    }
 }

--- a/lib/calendar/calendars_controller_screen.php
+++ b/lib/calendar/calendars_controller_screen.php
@@ -12,6 +12,7 @@ class pz_calendars_controller_screen extends pz_calendars_controller
     {
         if (!in_array($function, $this->functions)) {
             $function = $this->function_default;
+            $this->removeSelectDay();
         }
         $this->function = $function;
 
@@ -230,7 +231,8 @@ class pz_calendars_controller_screen extends pz_calendars_controller
         $s1_content = '';
         $s2_content = '';
 
-        $request_day = rex_request('day', 'string'); // 20112019 Ymd
+        $request_day = $this->getSelectDay();
+
         if (!$day = DateTime::createFromFormat('Ymd', $request_day)) {
             $day = new DateTime();
         }
@@ -332,7 +334,8 @@ class pz_calendars_controller_screen extends pz_calendars_controller
         $s1_content = '';
         $s2_content = '';
 
-        $request_day = rex_request('day', 'string'); // 20112019 Ymd
+        $request_day = $request_day = $this->getSelectDay();
+
         if (!$day = DateTime::createFromFormat('Ymd', $request_day)) {
             $day = new DateTime();
         }
@@ -458,7 +461,7 @@ class pz_calendars_controller_screen extends pz_calendars_controller
         $s1_content = '';
         $s2_content = '';
 
-        $request_day = rex_request('day', 'string'); // 20112019 Ymd
+        $request_day = $this->getSelectDay(); // 20112019 Ymd
 
         // Ansichten:
         // - 14 tägig


### PR DESCRIPTION
Wenn ich einen Tag selektiert hab, wird dieser dann auch für die
Wochenansicht, Tagesansicht und Kundenansicht verwendet.
Bis ich wieder neu auf den Kalender komme.

closed #386